### PR TITLE
issues with symbols in todo title fixed

### DIFF
--- a/krypto/todo.py
+++ b/krypto/todo.py
@@ -112,11 +112,9 @@ def parse(
             start = True
             possible.append((index, line))
         elif start and line.startswith(PREFIX):
-            start = False
             todo = process_raw_todo(possible, prefix=PREFIX)
             result.append(todo)
-            todo = process_raw_todo([(index, line)], prefix=PREFIX)
-            result.append(todo)
+            possible = [(index, line)]
         elif start and line.startswith(COMMENT_SYMBOL):
             possible.append((index, line))
         elif start and not line.startswith(COMMENT_SYMBOL):

--- a/krypto/todo.py
+++ b/krypto/todo.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, field
 from krypto.config import SYMBOLS
 
 SEPARATORS = r"[\s?,-/~#\\\s\s?]+"
-PATTERN = r"{}(\[([a-zA-Z{}]*)?\])?:([\d\w\s\-]*)(?:\s\@\s.*)?"
+PATTERN = r"{}(\[([a-zA-Z{}]*)?\])?:(.*)(?:\s\@\s.*)?"
 
 
 # TODO[Enhancement]: Add functionality for multiline comments in js @https://github.com/antoniouaa/krypto/issues/50

--- a/tests/test_todo.py
+++ b/tests/test_todo.py
@@ -46,12 +46,17 @@ def test_todo_many():
 def test_func(*args, **kwargs):
     # TODO: Implement this function
     # TODO: Check if the assertions pass
+    # TODO: Check if the third one is registered
+    # TODO: Check if the fourth one is registered
+    # TODO: Check if the fifth one is registered
 """
     todos = parse(test_program, extension="py", todo_prefix="TODO")
-    print(todos)
-    assert len(todos) == 2
+    assert len(todos) == 5
     assert todos[0].title == "Implement this function"
     assert todos[1].title == "Check if the assertions pass"
+    assert todos[2].title == "Check if the third one is registered"
+    assert todos[3].title == "Check if the fourth one is registered"
+    assert todos[4].title == "Check if the fifth one is registered"
 
 
 def test_todo_with_body():
@@ -100,11 +105,16 @@ const testFunc = () => {
 
 def test_todo_with_dot():
     test_program = """
+def func():
     # TODO: ensure foo.bar works
-    # body here    
+    # TODO: ensure foo-bar works too
+    # TODO: check other symbols/ ?'
     """
-    todos = parse(test_program, extension="py", todo_prefix="TODO")
-    assert len(todos) == 1
-    todo = todos[0]
-    assert todo.title == "ensure foo.bar works"
-    assert todo.body == "body here"
+    todos = parse(test_program, extension="py")
+    assert len(todos) == 3
+    assert todos[0].title == "ensure foo.bar works"
+    assert todos[0].body == ""
+    assert todos[1].title == "ensure foo-bar works too"
+    assert todos[1].body == ""
+    assert todos[2].title == "check other symbols/ ?'"
+    assert todos[2].body == ""

--- a/tests/test_todo.py
+++ b/tests/test_todo.py
@@ -96,3 +96,15 @@ const testFunc = () => {
     todo = todos[0]
     assert todo.title == "Implement this function"
     assert todo.body == "This function should perform some task and return some output"
+
+
+def test_todo_with_dot():
+    test_program = """
+    # TODO: ensure foo.bar works
+    # body here    
+    """
+    todos = parse(test_program, extension="py", todo_prefix="TODO")
+    assert len(todos) == 1
+    todo = todos[0]
+    assert todo.title == "ensure foo.bar works"
+    assert todo.body == "body here"


### PR DESCRIPTION
Hopefully fixes #52
Replaces the regex for extracting the title of the todo with `.*`. Passes all test cases.